### PR TITLE
Add agent cost tracking with underlying model resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 LibreChat Exporter is a Python-based monitoring tool that extracts metrics from LibreChat's MongoDB database and exposes them in Prometheus-compatible format. It provides real-time metrics collection for monitoring via Prometheus and Grafana.
 
+### Repository Information
+- **Upstream**: https://github.com/virtUOS/librechat_exporter
+- **This Fork**: https://github.com/e-gineering/librechat_exporter
+- **Production Instance**: Accessible via `ssh -i ~/.ssh/tardis root@libre`
+  - LibreChat directory: `~/LibreChat`
+  - Started with Docker Compose override file
+  - Uses E-gineering's librechat_exporter image from GHCR
+
 ## Core Architecture
 
 The system provides real-time monitoring:
@@ -71,6 +79,7 @@ Follow conventional commits with **sentence case** formatting:
 - **`conversations`**: Chat conversations with timestamps
 - **`files`**: Uploaded files metadata  
 - **`users`**: Registered user accounts
+- **`agents`**: Agent definitions with `id`, `name`, `model` (underlying model), `tools` (array of tool names)
 
 ### Historical Data Storage
 Historical data is stored in Prometheus with configurable retention periods. Use PromQL queries to analyze trends over time.

--- a/metrics.py
+++ b/metrics.py
@@ -38,6 +38,7 @@ class LibreChatMetricsCollector(Collector):
         self.messages_collection = self.db["messages"]
         self.users_collection = self.db["users"]
         self.conversations_collection = self.db["conversations"]
+        self.agents_collection = self.db["agents"]
 
     def collect(self):
         """
@@ -707,6 +708,60 @@ class LibreChatMetricsCollector(Collector):
         """
         return f"{cost:.12f}".rstrip("0").rstrip(".")
 
+    @lru_cache(maxsize=256)
+    def get_agent_info(self, agent_id):
+        """
+        Get agent information from the agents collection.
+
+        Args:
+            agent_id: Agent ID (e.g. 'agent_UBIc4ySL0k4GRSnQmiIEO')
+
+        Returns:
+            dict: Agent info with 'name', 'model', and 'tools' fields, or None if not found
+        """
+        try:
+            agent = self.agents_collection.find_one({"id": agent_id}, {"name": 1, "model": 1, "tools": 1, "_id": 0})
+            if agent:
+                logger.debug(
+                    "Found agent %s: name=%s, model=%s, tools=%s",
+                    agent_id,
+                    agent.get("name"),
+                    agent.get("model"),
+                    agent.get("tools"),
+                )
+                return agent
+            else:
+                logger.debug("Agent %s not found in agents collection", agent_id)
+                return None
+        except Exception as e:
+            logger.warning("Error looking up agent %s: %s", agent_id, e)
+            return None
+
+    def resolve_model_for_pricing(self, model_str):
+        """
+        Resolve the actual model to use for pricing lookup.
+        If the model is an agent (starts with 'agent_'), look up the underlying model.
+
+        Args:
+            model_str: Model string from message (e.g. 'gpt-4o' or 'agent_UBIc4ySL0k4GRSnQmiIEO')
+
+        Returns:
+            tuple: (actual_model_for_pricing, agent_name or None)
+        """
+        if model_str and model_str.startswith("agent_"):
+            agent_info = self.get_agent_info(model_str)
+            if agent_info:
+                underlying_model = agent_info.get("model")
+                agent_name = agent_info.get("name", model_str)
+                logger.debug(
+                    "Resolved agent %s to underlying model %s (agent name: %s)", model_str, underlying_model, agent_name
+                )
+                return underlying_model, agent_name
+            else:
+                logger.warning("Agent %s not found in database - cannot resolve underlying model", model_str)
+                return model_str, None
+        return model_str, None
+
     @lru_cache(maxsize=1)  # Cache the pricing data fetch with TTL
     def get_pricing_data(self, ttl_hash=None):
         """
@@ -774,6 +829,7 @@ class LibreChatMetricsCollector(Collector):
     def collect_usage_cost_total(self):
         """
         Collect total usage costs in USD per model and user.
+        For agents, resolves the underlying model and uses its pricing.
         """
         try:
             pipeline = [
@@ -810,13 +866,13 @@ class LibreChatMetricsCollector(Collector):
             metric = CounterMetricFamily(
                 "librechat_usage_cost_total_usd",
                 "Total API usage costs in USD",
-                labels=["model", "user_email"],
+                labels=["model", "user_email", "agent_name"],
             )
 
             # Get TTL hash for 1-hour cache
             ttl_hash = self.get_ttl_hash(3600)
 
-            # Track costs per model/user combination
+            # Track costs per model/user/agent combination
             cost_aggregates = {}
 
             for result in results:
@@ -825,14 +881,30 @@ class LibreChatMetricsCollector(Collector):
                 sender = result["_id"]["sender"]
                 token_count = result["totalTokens"]
 
-                # Get cached pricing data (logs cache hits vs API calls)
-                input_cost_per_token, output_cost_per_token = self.get_cached_cost_per_token(model, ttl_hash=ttl_hash)
-                logger.debug(
-                    "Using pricing for model %s: input=$%s/token, output=$%s/token",
-                    model,
-                    self.format_cost(input_cost_per_token),
-                    self.format_cost(output_cost_per_token),
+                # Resolve agent to underlying model for pricing
+                pricing_model, agent_name = self.resolve_model_for_pricing(model)
+                agent_label = agent_name if agent_name else ""
+
+                # Get cached pricing data
+                input_cost_per_token, output_cost_per_token = self.get_cached_cost_per_token(
+                    pricing_model, ttl_hash=ttl_hash
                 )
+
+                if agent_name:
+                    logger.debug(
+                        "Using pricing for agent %s (underlying model %s): input=$%s/token, output=$%s/token",
+                        agent_name,
+                        pricing_model,
+                        self.format_cost(input_cost_per_token),
+                        self.format_cost(output_cost_per_token),
+                    )
+                else:
+                    logger.debug(
+                        "Using pricing for model %s: input=$%s/token, output=$%s/token",
+                        model,
+                        self.format_cost(input_cost_per_token),
+                        self.format_cost(output_cost_per_token),
+                    )
 
                 # Calculate cost based on sender type
                 if sender == "User":
@@ -840,15 +912,16 @@ class LibreChatMetricsCollector(Collector):
                 else:
                     cost = token_count * output_cost_per_token
 
-                # Aggregate costs by model and user
-                key = (model, email)
+                # Aggregate costs by model, user, and agent
+                key = (model, email, agent_label)
                 if key not in cost_aggregates:
                     cost_aggregates[key] = 0.0
                 cost_aggregates[key] += cost
 
                 logger.debug(
-                    "Cost calculation: model=%s, user=%s, sender=%s, tokens=%s, cost=$%s",
+                    "Cost calculation: model=%s, agent=%s, user=%s, sender=%s, tokens=%s, cost=$%s",
                     model,
+                    agent_label,
                     email,
                     sender,
                     token_count,
@@ -856,9 +929,18 @@ class LibreChatMetricsCollector(Collector):
                 )
 
             # Add aggregated costs to metric
-            for (model, email), total_cost in cost_aggregates.items():
-                metric.add_metric([model, email], total_cost)
-                logger.debug("Total cost for model %s, user %s: $%s", model, email, self.format_cost(total_cost))
+            for (model, email, agent_label), total_cost in cost_aggregates.items():
+                metric.add_metric([model, email, agent_label], total_cost)
+                if agent_label:
+                    logger.debug(
+                        "Total cost for agent %s (model %s), user %s: $%s",
+                        agent_label,
+                        model,
+                        email,
+                        self.format_cost(total_cost),
+                    )
+                else:
+                    logger.debug("Total cost for model %s, user %s: $%s", model, email, self.format_cost(total_cost))
 
             yield metric
         except Exception as e:

--- a/metrics.py
+++ b/metrics.py
@@ -165,7 +165,7 @@ class LibreChatMetricsCollector(Collector):
 
     def collect_message_count_per_model(self):
         """
-        Collect number of messages per model with user labels.
+        Collect number of messages per model with user labels and agent names.
         """
         try:
             pipeline = [
@@ -200,21 +200,26 @@ class LibreChatMetricsCollector(Collector):
             metric = GaugeMetricFamily(
                 "librechat_messages_per_model_total",
                 "Number of messages per model and user",
-                labels=["model", "user_email"],
+                labels=["model", "user_email", "agent_name"],
             )
             for result in results:
                 model = result["_id"]["model"] or "unknown"
                 email = result["_id"]["email"]
                 count = result["messageCount"]
-                metric.add_metric([model, email], count)
-                logger.debug("Message count for model %s, user %s: %s", model, email, count)
+
+                # Resolve agent name if this is an agent
+                _, agent_name = self.resolve_model_for_pricing(model)
+                agent_label = agent_name if agent_name else ""
+
+                metric.add_metric([model, email, agent_label], count)
+                logger.debug("Message count for model %s (agent: %s), user %s: %s", model, agent_label, email, count)
             yield metric
         except Exception as e:
             logger.exception("Error collecting messages count per model: %s", e)
 
     def collect_error_count_per_model(self):
         """
-        Collect number of error messages per model with user labels.
+        Collect number of error messages per model with user labels and agent names.
         """
         try:
             pipeline = [
@@ -244,21 +249,28 @@ class LibreChatMetricsCollector(Collector):
             metric = CounterMetricFamily(
                 "librechat_errors_per_model_total",
                 "Number of error messages per model and user",
-                labels=["model", "user_email"],
+                labels=["model", "user_email", "agent_name"],
             )
             for result in results:
                 model = result["_id"]["model"] or "unknown"
                 email = result["_id"]["email"]
                 error_count = result["errorCount"]
-                metric.add_metric([model, email], error_count)
-                logger.debug("Error count for model %s, user %s: %s", model, email, error_count)
+
+                # Resolve agent name if this is an agent
+                _, agent_name = self.resolve_model_for_pricing(model)
+                agent_label = agent_name if agent_name else ""
+
+                metric.add_metric([model, email, agent_label], error_count)
+                logger.debug(
+                    "Error count for model %s (agent: %s), user %s: %s", model, agent_label, email, error_count
+                )
             yield metric
         except Exception as e:
             logger.exception("Error collecting error messages per model: %s", e)
 
     def collect_input_token_count_per_model(self):
         """
-        Collect number of input tokens per model with user labels.
+        Collect number of input tokens per model with user labels and agent names.
         """
         try:
             pipeline = [
@@ -295,21 +307,26 @@ class LibreChatMetricsCollector(Collector):
             metric = GaugeMetricFamily(
                 "librechat_input_tokens_per_model_total",
                 "Number of input tokens per model and user",
-                labels=["model", "user_email"],
+                labels=["model", "user_email", "agent_name"],
             )
             for result in results:
                 model = result["_id"]["model"] or "unknown"
                 email = result["_id"]["email"]
                 tokens = result["totalInputTokens"]
-                metric.add_metric([model, email], tokens)
-                logger.debug("Input tokens for model %s, user %s: %s", model, email, tokens)
+
+                # Resolve agent name if this is an agent
+                _, agent_name = self.resolve_model_for_pricing(model)
+                agent_label = agent_name if agent_name else ""
+
+                metric.add_metric([model, email, agent_label], tokens)
+                logger.debug("Input tokens for model %s (agent: %s), user %s: %s", model, agent_label, email, tokens)
             yield metric
         except Exception as e:
             logger.exception("Error collecting number of input tokens per model", e)
 
     def collect_output_token_count_per_model(self):
         """
-        Collect number of output tokens per model with user labels.
+        Collect number of output tokens per model with user labels and agent names.
         """
         try:
             pipeline = [
@@ -346,14 +363,19 @@ class LibreChatMetricsCollector(Collector):
             metric = GaugeMetricFamily(
                 "librechat_output_tokens_per_model_total",
                 "Number of output tokens per model and user",
-                labels=["model", "user_email"],
+                labels=["model", "user_email", "agent_name"],
             )
             for result in results:
                 model = result["_id"]["model"] or "unknown"
                 email = result["_id"]["email"]
                 tokens = result["totalOutputTokens"]
-                metric.add_metric([model, email], tokens)
-                logger.debug("Output tokens for model %s, user %s: %s", model, email, tokens)
+
+                # Resolve agent name if this is an agent
+                _, agent_name = self.resolve_model_for_pricing(model)
+                agent_label = agent_name if agent_name else ""
+
+                metric.add_metric([model, email, agent_label], tokens)
+                logger.debug("Output tokens for model %s (agent: %s), user %s: %s", model, agent_label, email, tokens)
             yield metric
         except Exception as e:
             logger.exception("Error collecting number of output tokens per model", e)


### PR DESCRIPTION
## Summary

Adds comprehensive agent cost tracking to the LibreChat exporter by resolving agent IDs to their underlying models and using accurate pricing data.

## Changes

### Core Features
- **Agent Resolution**: Automatically detects when a model is an agent (starts with `agent_`) and looks up the underlying model from MongoDB's `agents` collection
- **Accurate Cost Calculation**: Uses underlying model pricing (e.g., `gpt-4o`, `claude-sonnet-4-5`) instead of showing $0.00 for agents
- **Friendly Names**: Adds `agent_name` label to all per-model metrics for better readability in Grafana

### Technical Implementation

**New Methods**:
- `get_agent_info(agent_id)` - Fetches agent details (name, model, tools) from MongoDB with LRU caching
- `resolve_model_for_pricing(model_str)` - Resolves agent IDs to underlying models for pricing lookups

**Updated Metrics** (all now include `agent_name` label):
- `librechat_usage_cost_total_usd` - Now calculates accurate costs for agents
- `librechat_messages_per_model_total`
- `librechat_errors_per_model_total`
- `librechat_input_tokens_per_model_total`
- `librechat_output_tokens_per_model_total`

**Documentation**:
- Updated `CLAUDE.md` with repository information and agents collection schema

## Example

**Before**:
```
2026-01-06 20:09:52,708 - WARNING - Model agent_HQL2sL4U8VrcsAHw7ycQ2 not found in pricing data - using fallback cost $0.00
```

**After**:
```
2026-01-06 20:15:32,142 - DEBUG - Resolved agent agent_HQL2sL4U8VrcsAHw7ycQ2 to underlying model claude-sonnet-4-5 (agent name: All Might)
2026-01-06 20:15:32,143 - DEBUG - Using pricing for agent All Might (underlying model claude-sonnet-4-5): input=$0.000003/token, output=$0.000015/token
```

## Grafana Integration

With the new `agent_name` label, Grafana queries can now display friendly names:

```promql
# Shows "All Might" instead of "agent_HQL2sL4U8VrcsAHw7ycQ2"
sum by (display_name) (
  label_replace(
    librechat_usage_cost_total_usd{agent_name!=""},
    "display_name", "$1", "agent_name", "(.+)"
  )
  or
  label_replace(
    librechat_usage_cost_total_usd{agent_name=""},
    "display_name", "$1", "model", "(.+)"
  )
)
```

## Testing

- ✅ Code passes `ruff check` and `ruff format`
- ✅ Successfully tested in production environment
- ✅ Backward compatible (empty `agent_name` label for non-agents)
- ✅ Metrics validated against live LibreChat instance

## Breaking Changes

None - adds new label without removing existing ones.